### PR TITLE
Docs - Quick Start

### DIFF
--- a/content/design/tutorials/getting-started.md
+++ b/content/design/tutorials/getting-started.md
@@ -160,7 +160,7 @@ Same as python: while. (Note: Python's else clause on while is not supported)
 while a < 5:
   a += 1
 ```
-If a is 10 at the beginning, a will be 15 at the end.
+If a is 0 at the beginning, a will be 5 at the end.
 
 ## For
 Same as python: for. (Note: Python's else clause on for is not supported)

--- a/content/design/tutorials/quick-start.md
+++ b/content/design/tutorials/quick-start.md
@@ -448,8 +448,8 @@ Now, we can fill in the `GossipTimer` on the sender and `gossip` function for th
 {{% fizzbee %}}
 ---
 action_options:
-       "Server#.GossipTimer":
-              max_concurrent_actions: 1
+    "Server#.GossipTimer":
+        max_concurrent_actions: 1
 ---
 
 NUM_SERVERS=2  # Reducing the number of servers to 2 temporarily. We will increase it later.

--- a/content/design/tutorials/quick-start.md
+++ b/content/design/tutorials/quick-start.md
@@ -273,7 +273,7 @@ label="servers";
 In the gossip protocol, we expect only one RPC method. Let's call it `gossip()` in each of these servers.
 
 ```python
-    func gossip(cache):
+    func gossip(received_cache):
         pass  # Empty block, we'll fill this later
 ```
 Someone should trigger this. Let's add a `GossipTimer` action to the `Server` role.
@@ -289,7 +289,7 @@ The GossipTimer will trigger the `gossip` method in an arbitrarily selected serv
     action GossipTimer:
         i = any range(NUM_SERVERS)
         server = servers[i]
-        server.gossip(cache)
+        server.gossip(self.cache)
 ```
 
 Here, `any` keyword indicates, we are selection one of the elements on the collection arbitrarily.
@@ -309,7 +309,7 @@ role Server:
         server = servers[i]
         server.gossip(self.cache)
 
-    func gossip(cache):
+    func gossip(received_cache):
         pass  # Empty block, we'll fill this later
 
 
@@ -384,7 +384,7 @@ role Server:
         server = servers[i]
         server.gossip(self.cache)
 
-    func gossip(cache):
+    func gossip(received_cache):
         pass  # Empty block, we'll fill this later
 
 

--- a/content/design/tutorials/quick-start.md
+++ b/content/design/tutorials/quick-start.md
@@ -990,12 +990,12 @@ For the gossip protocol, the safety property is not that relevant, but just as a
 
 The cached version of any server should never be less than the remote server's version.
 
-We can represent it with
+We can represent it with:
 ```python
 always assertion CachedVersionBelowActualVersion:
     return all([server.cache[i] <= servers[i].version for server in servers for i in range(NUM_SERVERS)])
 ```
-For forks, not familiar with Python, this is the same as
+For those not familiar with Python, this is the same as:
 ```python
 always assertion CachedVersionBelowActualVersion:
     for server in servers:

--- a/content/design/tutorials/quick-start.md
+++ b/content/design/tutorials/quick-start.md
@@ -564,11 +564,11 @@ For now, let us limit the number of actions that can be run concurrently to 1.
 ```yaml
 ---
 options:
-       max_concurrent_actions: 1
+    max_concurrent_actions: 1
 action_options:
-       "Server#.GossipTimer":
-              # This is not needed, as global max_concurrent_actions will be applied to all actions.
-              max_concurrent_actions: 1
+    "Server#.GossipTimer":
+        # This is not needed, as global max_concurrent_actions will be applied to all actions.
+        max_concurrent_actions: 1
 ---
 ```
 With this setting, if you run with 2 servers, it will produce around 70 states and 

--- a/content/design/tutorials/quick-start.md
+++ b/content/design/tutorials/quick-start.md
@@ -612,10 +612,10 @@ action_options:
     "Server#.GossipTimer":
         max_concurrent_actions: 1
 ```
-Notice the `Server.BumpVersion`. This means, the `BumpVersion` action can only be run once acros all `Server` instances.
-Whereas, if it was `Server#.BumpVersion`, it would mean, each `Server` instance can run the `BumpVersion` action once.
+Notice the `Server.BumpVersion`. This means that the `BumpVersion` action can only be run once acros all `Server` instances.
+If it were `Server#.BumpVersion`, it would mean that each `Server` instance can run the `BumpVersion` action once.
 
-Now, we run the model checker, and explore the states.
+Now we run the model checker and explore the states.
 
 {{% fizzbee %}}
 ---
@@ -759,7 +759,7 @@ label="servers";
 
 
 ## Add Durability and Ephemeral Annotations
-In our design, the `version` is a durable state, and the `cache` is ephemeral. In FizzBee, by default 
+In our design, the `version` is a durable state and the `cache` is ephemeral. In FizzBee, by default 
 all state are assumed to be durable. To mark the `cache` as ephemeral, we just need to set an annotation.
 
 ```python
@@ -812,10 +812,10 @@ action Init:
 
 
 {{% /fizzbee %}}
-Now, when you run the model checker and try the state explorer, you will see a few more action buttons titled
-`crash-role Server#0`, `crash-role Server#0` and `crash-role Server#0`. When you click one of these,
+Now when you run the model checker and try the state explorer, you will see a few more action buttons titled
+`crash-role Server#0`, `crash-role Server#0` and `crash-role Server#0`. When you click one of these
 it simulates a process restart. You will see the ephemeral data (`cache`) wiped out to its initial state
-but the `version` would be preserved. 
+but the `version` will be preserved. 
 
 For example, lets get to this state.
 
@@ -903,7 +903,7 @@ label="servers";
 }
 {{% /graphviz %}}
 
-Now, click on `crash-role Server#0`, the new state would look like,
+Now click on `crash-role Server#0`. The new state would look like:
 {{% graphviz %}}
 digraph G {
 compound=true;

--- a/content/design/tutorials/quick-start.md
+++ b/content/design/tutorials/quick-start.md
@@ -1010,12 +1010,11 @@ Due to the implementation details, the first version runs much faster than the s
 Liveness properties are those that must eventually be true. While safety property actually says, nothing bad ever happens,
 liveness property says, something good eventually happens.
 
-For the gossip protocol, we can say, eventually, all servers should have the same version.
+For this gossip protocol, all servers should eventually have the same version.
 
 ```python
-
 always eventually assertion ConsistentCache:
-  return all([server.cache[i] == servers[i].version for server in servers for i in range(NUM_SERVERS)])
+    return all([server.cache[i] == servers[i].version for server in servers for i in range(NUM_SERVERS)])
 
 ```
 {{% fizzbee %}}
@@ -1098,13 +1097,12 @@ diff tmp/spec1.txt tmp/spec2.txt
 
 ```
 
-Now, when you run, you won't see any error.
+When you run this, you won't see any error.
 
 Now, try increasing the number of servers to 4. You will see the liveness property failing.
-But unfortunately, in the online playground the number of states would have exceeded so high, it will timeout.
+Unfortunately this will time out in the online playground since the number of states exceeds the maximum.
 
-We can temporarily reduce the statespace further by marking the gossip action as atomic and probably remove the BumpVersion action
-as well.
+We can temporarily reduce the statespace by marking the gossip action as atomic and removingf the BumpVersion action.
 
 ```diff
 11c11
@@ -1176,11 +1174,10 @@ action Init:
 
 {{% /fizzbee %}}
 
-When you run this spec, you'll see an error. The generated trace for liveness is not the shortest at this moment. 
-But if you open the error graph, and scroll to the bottom right, you will see, there is a possibility that
-two servers might choose each other and form a partition to gossip, and so the information about
-some server do not reach some others. 
-That is because, even though all servers are gossiping as we marked them fair, we didn't specify
+When you run this spec, you'll see an error. The generated trace for liveness is rather long,
+but if you open the error graph and scroll to the bottom right you should see a scenario where
+two servers choose each other, forming a partition. This prevents state information from reaching some servers.
+This is because, even though all servers are gossiping as we marked them fair, we didn't specify
 how they should select the server to communicate with. Specifically this line.
 
 ```python
@@ -1205,9 +1202,8 @@ sequenceDiagram
 	'Server#2' --&gt;&gt; 'Server#3': ([0, 0, 1, 1])
 {{% /mermaid %}}
 
-Imagine, in the implementation, each server maintains a `set` of urls for other servers, and it selects the first one each time.
-So this could cause the liveness issue. To fix this, in the implementation, all we need to do is,
-select a random server from the set of urls.
+Imagine, in the implementation, each server maintains a `set` of urls for other servers and selects the first one each time.
+This could cause the liveness issue. To fix this in the implementation, all we need to do is select a random server from the set of urls.
 That is, we will make a fair selection of the server to gossip with.
 
 ```diff


### PR DESCRIPTION
- Fixes inconsistent variable names in code samples
- Fixes code formatting errors (double yaml tabs)
- Fixes grammatical and spelling errors